### PR TITLE
Added missing show() and enableExtension() functions to the .d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,5 +21,7 @@ declare class GameStats {
 	constructor(options?: Options)
 	begin: (label?: string, color?: string) => void;
 	end: (label?: string, color?: string) => void;
+	show: (visible: boolean) => void;
+	enableExtension: (name: string, params: any[]) => Promise<void>;
 }
 export default GameStats;


### PR DESCRIPTION
They're both pretty useful, having them exposed allows me not to cast to `any`.

I didn't bump the version number, I'll let the authors deal with that :) 